### PR TITLE
Remove committed binary archive and document local packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # core00
+
+This repository no longer stores the generated `geo_auction_flutter.zip` archive under version control.
+If you need to bundle the Flutter project for distribution, create the archive locally with:
+
+```bash
+zip -r geo_auction_flutter.zip geo_auction_flutter
+```
+
+This command should be run from the repository root and will package the `geo_auction_flutter/` directory into a
+fresh ZIP file as needed.


### PR DESCRIPTION
## Summary
- document that the generated `geo_auction_flutter.zip` archive should be built locally as needed
- provide the exact `zip` command contributors can run from the repository root

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cef661f834832fb378d1063625d359